### PR TITLE
fix: ウィンドウ赤ボタンの閉じる動作追加

### DIFF
--- a/src/components/app-window/AppWindow.jsx
+++ b/src/components/app-window/AppWindow.jsx
@@ -98,7 +98,7 @@ export function AppWindow({ threadType, selectedWork, threadState, shellProps = 
   const gridStyle = isDesktop
     ? { gridTemplateColumns: `${columnWidths.left}px minmax(0, 1fr) ${columnWidths.right}px` }
     : undefined;
-  const { onHeaderPointerDown, onToggleMaximize, isMaximized } = shellProps;
+  const { onHeaderPointerDown, onClose, onToggleMaximize, isMaximized } = shellProps;
 
   return (
     <WindowShell
@@ -116,6 +116,7 @@ export function AppWindow({ threadType, selectedWork, threadState, shellProps = 
             activeThreadType={threadType}
             selectedWorkId={selectedWork?.id ?? null}
             onHeaderPointerDown={onHeaderPointerDown}
+            onClose={onClose}
             onToggleMaximize={onToggleMaximize}
             isMaximized={isMaximized}
           />

--- a/src/components/app-window/LeftSidebar.jsx
+++ b/src/components/app-window/LeftSidebar.jsx
@@ -17,6 +17,7 @@ export function LeftSidebar({
   activeThreadType,
   selectedWorkId,
   onHeaderPointerDown,
+  onClose,
   onToggleMaximize,
   isMaximized = false,
 }) {
@@ -50,7 +51,7 @@ export function LeftSidebar({
         }`}
       >
         <div className="flex items-center justify-between">
-          <WindowControlButtons onToggleMaximize={onToggleMaximize} isMaximized={isMaximized} />
+          <WindowControlButtons onClose={onClose} onToggleMaximize={onToggleMaximize} isMaximized={isMaximized} />
           <div className="flex items-center gap-1 text-white/28">
             <button
               type="button"

--- a/src/components/desktop/TerminalWindowShell.jsx
+++ b/src/components/desktop/TerminalWindowShell.jsx
@@ -4,6 +4,7 @@ export function TerminalWindowShell({
   title,
   onWindowPointerDown,
   onHeaderPointerDown,
+  onClose,
   onToggleMaximize,
   isMaximized = false,
   active = false,
@@ -23,7 +24,7 @@ export function TerminalWindowShell({
           onHeaderPointerDown ? 'cursor-grab active:cursor-grabbing' : ''
         }`}
       >
-        <WindowControlButtons onToggleMaximize={onToggleMaximize} isMaximized={isMaximized} />
+        <WindowControlButtons onClose={onClose} onToggleMaximize={onToggleMaximize} isMaximized={isMaximized} />
 
         <div className="min-w-0 flex-1 px-4 text-center text-[11px] font-medium text-white/72">
           <span className="truncate">{title}</span>

--- a/src/components/desktop/WindowControlButtons.jsx
+++ b/src/components/desktop/WindowControlButtons.jsx
@@ -1,11 +1,14 @@
-export function WindowControlButtons({ onToggleMaximize, isMaximized = false, className = '' }) {
+export function WindowControlButtons({ onClose, onToggleMaximize, isMaximized = false, className = '' }) {
   return (
     <div className={`flex items-center gap-2 ${className}`}>
       <button
         type="button"
         aria-label="close window"
         onPointerDown={(event) => event.stopPropagation()}
-        onClick={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation();
+          onClose?.();
+        }}
         className="h-3 w-3 rounded-full bg-[#ff5f57]"
       />
       <button

--- a/src/components/workspace/WorkspaceScreen.jsx
+++ b/src/components/workspace/WorkspaceScreen.jsx
@@ -32,6 +32,7 @@ export function WorkspaceScreen({
     desktopViewportRef,
     dragState,
     terminalShellProps,
+    visibleWindows,
     windowFrameRefs,
     windowFrames,
   } = useDesktopWindows(displayMode);
@@ -55,21 +56,25 @@ export function WorkspaceScreen({
         <div className="desktop-window-reveal relative flex-1 overflow-hidden px-3 pt-3 sm:px-5 sm:pt-5 lg:p-0">
           <div className="flex h-full flex-col gap-4 lg:hidden">
             {displayMode === 'cli' ? (
-              <div className="min-h-0 flex-1">
-                <LauncherTerminalWindow
-                  threadType={effectiveThreadType}
-                  selectedWork={selectedWork}
-                  threadState={threadState}
-                  displayMode={displayMode}
-                  terminalCommand={terminalCommand}
-                  terminalLog={terminalLog}
-                  onTerminalCommandChange={onTerminalCommandChange}
-                  onTerminalSubmit={onTerminalSubmit}
-                />
-              </div>
+              visibleWindows.terminal ? (
+                <div className="min-h-0 flex-1">
+                  <LauncherTerminalWindow
+                    threadType={effectiveThreadType}
+                    selectedWork={selectedWork}
+                    threadState={threadState}
+                    displayMode={displayMode}
+                    terminalCommand={terminalCommand}
+                    terminalLog={terminalLog}
+                    onTerminalCommandChange={onTerminalCommandChange}
+                    onTerminalSubmit={onTerminalSubmit}
+                    shellProps={terminalShellProps}
+                  />
+                </div>
+              ) : null
             ) : (
               <>
-                <div className="shrink-0">
+                {visibleWindows.terminal ? (
+                  <div className="shrink-0">
                     <LauncherTerminalWindow
                       threadType={effectiveThreadType}
                       selectedWork={selectedWork}
@@ -79,12 +84,19 @@ export function WorkspaceScreen({
                       terminalLog={terminalLog}
                       onTerminalCommandChange={onTerminalCommandChange}
                       onTerminalSubmit={onTerminalSubmit}
+                      shellProps={terminalShellProps}
                     />
-                </div>
+                  </div>
+                ) : null}
 
-                {displayMode === 'app' ? (
+                {visibleWindows.app ? (
                   <div className="min-h-0 flex-1">
-                    <AppWindow threadType={effectiveThreadType} selectedWork={selectedWork} threadState={threadState} />
+                    <AppWindow
+                      threadType={effectiveThreadType}
+                      selectedWork={selectedWork}
+                      threadState={threadState}
+                      shellProps={appShellProps}
+                    />
                   </div>
                 ) : null}
               </>
@@ -92,19 +104,20 @@ export function WorkspaceScreen({
           </div>
 
           <div ref={desktopViewportRef} className="relative hidden h-full lg:block">
-            <div
-              ref={(node) => {
-                windowFrameRefs.current.terminal = node;
-              }}
-              style={{
-                left: `${windowFrames.terminal.x}px`,
-                top: `${windowFrames.terminal.y}px`,
-                width: `${windowFrames.terminal.width}px`,
-                height: `${windowFrames.terminal.height}px`,
-                zIndex: activeWindow === 'terminal' ? 30 : 20,
-              }}
-              className={`desktop-window-frame absolute ${dragState?.key === 'terminal' ? 'desktop-window-frame--dragging' : ''}`}
-            >
+            {visibleWindows.terminal ? (
+              <div
+                ref={(node) => {
+                  windowFrameRefs.current.terminal = node;
+                }}
+                style={{
+                  left: `${windowFrames.terminal.x}px`,
+                  top: `${windowFrames.terminal.y}px`,
+                  width: `${windowFrames.terminal.width}px`,
+                  height: `${windowFrames.terminal.height}px`,
+                  zIndex: activeWindow === 'terminal' ? 30 : 20,
+                }}
+                className={`desktop-window-frame absolute ${dragState?.key === 'terminal' ? 'desktop-window-frame--dragging' : ''}`}
+              >
                 <LauncherTerminalWindow
                   threadType={effectiveThreadType}
                   selectedWork={selectedWork}
@@ -115,10 +128,11 @@ export function WorkspaceScreen({
                   onTerminalCommandChange={onTerminalCommandChange}
                   onTerminalSubmit={onTerminalSubmit}
                   shellProps={terminalShellProps}
-              />
-            </div>
+                />
+              </div>
+            ) : null}
 
-            {displayMode === 'app' ? (
+            {visibleWindows.app ? (
               <div
                 ref={(node) => {
                   windowFrameRefs.current.app = node;

--- a/src/hooks/useDesktopWindows.js
+++ b/src/hooks/useDesktopWindows.js
@@ -11,6 +11,7 @@ export function useDesktopWindows(displayMode) {
     getDesktopWindowFrames(desktopArea.width, desktopArea.height, displayMode),
   );
   const [activeWindow, setActiveWindow] = useState(displayMode === 'app' ? 'app' : 'terminal');
+  const [closedWindows, setClosedWindows] = useState(() => ({ terminal: false, app: false }));
   const [dragState, setDragState] = useState(null);
   const windowFrameRefs = useRef({ terminal: null, app: null });
   const windowAnimationRefs = useRef({ terminal: null, app: null });
@@ -132,6 +133,12 @@ export function useDesktopWindows(displayMode) {
   }, []);
 
   useEffect(() => {
+    setClosedWindows({ terminal: false, app: false });
+    setActiveWindow(displayMode === 'app' ? 'app' : 'terminal');
+    setDragState(null);
+  }, [displayMode]);
+
+  useEffect(() => {
     if (!isDesktop) {
       previousDisplayModeRef.current = displayMode;
       return;
@@ -199,6 +206,10 @@ export function useDesktopWindows(displayMode) {
   }, [desktopArea.height, desktopArea.width, dragState, isDesktop]);
 
   function focusWindow(windowKey) {
+    if (closedWindows[windowKey]) {
+      return;
+    }
+
     setActiveWindow(windowKey);
   }
 
@@ -224,7 +235,7 @@ export function useDesktopWindows(displayMode) {
   }
 
   function toggleWindowMaximize(windowKey) {
-    if (!isDesktop) {
+    if (!isDesktop || closedWindows[windowKey]) {
       return;
     }
 
@@ -270,9 +281,39 @@ export function useDesktopWindows(displayMode) {
     playWindowFrameFlip(windowKey, firstRect, nextFrame);
   }
 
+  function closeWindow(windowKey) {
+    cancelWindowFrameAnimation(windowKey, true);
+    setDragState((currentDragState) => (currentDragState?.key === windowKey ? null : currentDragState));
+    setClosedWindows((currentClosedWindows) => ({
+      ...currentClosedWindows,
+      [windowKey]: true,
+    }));
+    setActiveWindow((currentActiveWindow) => {
+      if (currentActiveWindow !== windowKey) {
+        return currentActiveWindow;
+      }
+
+      if (windowKey === 'app' && !closedWindows.terminal) {
+        return 'terminal';
+      }
+
+      if (windowKey === 'terminal' && displayMode === 'app' && !closedWindows.app) {
+        return 'app';
+      }
+
+      return null;
+    });
+  }
+
+  const visibleWindows = {
+    terminal: !closedWindows.terminal,
+    app: displayMode === 'app' && !closedWindows.app,
+  };
+
   const terminalShellProps = {
     active: activeWindow === 'terminal',
     isMaximized: Boolean(windowFrames.terminal?.isMaximized),
+    onClose: () => closeWindow('terminal'),
     onWindowPointerDown: () => focusWindow('terminal'),
     onHeaderPointerDown: (event) => startWindowDrag('terminal', event),
     onToggleMaximize: () => toggleWindowMaximize('terminal'),
@@ -281,6 +322,7 @@ export function useDesktopWindows(displayMode) {
   const appShellProps = {
     active: activeWindow === 'app',
     isMaximized: Boolean(windowFrames.app?.isMaximized),
+    onClose: () => closeWindow('app'),
     onWindowPointerDown: () => focusWindow('app'),
     onHeaderPointerDown: (event) => startWindowDrag('app', event),
     onToggleMaximize: () => toggleWindowMaximize('app'),
@@ -292,6 +334,7 @@ export function useDesktopWindows(displayMode) {
     desktopViewportRef,
     dragState,
     terminalShellProps,
+    visibleWindows,
     windowFrameRefs,
     windowFrames,
   };


### PR DESCRIPTION
## 対応 issue
Closes #5

## 変更内容
- ウィンドウ左上の赤ボタンに閉じる処理を接続
- `terminal` / `app` の閉じた状態を `useDesktopWindows` で管理
- モバイル・デスクトップ両方で閉じたウィンドウを描画対象から外すよう変更

## 検証
- `npm run lint`
- `npm run build`
- `git diff --check`
- ブラウザ上でターミナル、アプリそれぞれの赤ボタン押下時に対象ウィンドウが消えることを確認