### PR TITLE
fix: モバイル緑ボタンの最大化対応

### DIFF
--- a/src/components/workspace/WorkspaceScreen.jsx
+++ b/src/components/workspace/WorkspaceScreen.jsx
@@ -74,7 +74,7 @@ export function WorkspaceScreen({
             ) : (
               <>
                 {visibleWindows.terminal ? (
-                  <div className="shrink-0">
+                  <div className={terminalShellProps.isMaximized ? 'min-h-0 flex-1' : 'shrink-0'}>
                     <LauncherTerminalWindow
                       threadType={effectiveThreadType}
                       selectedWork={selectedWork}

--- a/src/hooks/useDesktopWindows.js
+++ b/src/hooks/useDesktopWindows.js
@@ -12,6 +12,7 @@ export function useDesktopWindows(displayMode) {
   );
   const [activeWindow, setActiveWindow] = useState(displayMode === 'app' ? 'app' : 'terminal');
   const [closedWindows, setClosedWindows] = useState(() => ({ terminal: false, app: false }));
+  const [mobileMaximizedWindow, setMobileMaximizedWindow] = useState(null);
   const [dragState, setDragState] = useState(null);
   const windowFrameRefs = useRef({ terminal: null, app: null });
   const windowAnimationRefs = useRef({ terminal: null, app: null });
@@ -134,9 +135,16 @@ export function useDesktopWindows(displayMode) {
 
   useEffect(() => {
     setClosedWindows({ terminal: false, app: false });
+    setMobileMaximizedWindow(null);
     setActiveWindow(displayMode === 'app' ? 'app' : 'terminal');
     setDragState(null);
   }, [displayMode]);
+
+  useEffect(() => {
+    if (isDesktop) {
+      setMobileMaximizedWindow(null);
+    }
+  }, [isDesktop]);
 
   useEffect(() => {
     if (!isDesktop) {
@@ -235,7 +243,13 @@ export function useDesktopWindows(displayMode) {
   }
 
   function toggleWindowMaximize(windowKey) {
-    if (!isDesktop || closedWindows[windowKey]) {
+    if (closedWindows[windowKey]) {
+      return;
+    }
+
+    if (!isDesktop) {
+      setActiveWindow(windowKey);
+      setMobileMaximizedWindow((currentWindowKey) => (currentWindowKey === windowKey ? null : windowKey));
       return;
     }
 
@@ -284,6 +298,7 @@ export function useDesktopWindows(displayMode) {
   function closeWindow(windowKey) {
     cancelWindowFrameAnimation(windowKey, true);
     setDragState((currentDragState) => (currentDragState?.key === windowKey ? null : currentDragState));
+    setMobileMaximizedWindow((currentWindowKey) => (currentWindowKey === windowKey ? null : currentWindowKey));
     setClosedWindows((currentClosedWindows) => ({
       ...currentClosedWindows,
       [windowKey]: true,
@@ -306,13 +321,13 @@ export function useDesktopWindows(displayMode) {
   }
 
   const visibleWindows = {
-    terminal: !closedWindows.terminal,
-    app: displayMode === 'app' && !closedWindows.app,
+    terminal: !closedWindows.terminal && (!mobileMaximizedWindow || mobileMaximizedWindow === 'terminal'),
+    app: displayMode === 'app' && !closedWindows.app && (!mobileMaximizedWindow || mobileMaximizedWindow === 'app'),
   };
 
   const terminalShellProps = {
     active: activeWindow === 'terminal',
-    isMaximized: Boolean(windowFrames.terminal?.isMaximized),
+    isMaximized: isDesktop ? Boolean(windowFrames.terminal?.isMaximized) : mobileMaximizedWindow === 'terminal',
     onClose: () => closeWindow('terminal'),
     onWindowPointerDown: () => focusWindow('terminal'),
     onHeaderPointerDown: (event) => startWindowDrag('terminal', event),
@@ -321,7 +336,7 @@ export function useDesktopWindows(displayMode) {
 
   const appShellProps = {
     active: activeWindow === 'app',
-    isMaximized: Boolean(windowFrames.app?.isMaximized),
+    isMaximized: isDesktop ? Boolean(windowFrames.app?.isMaximized) : mobileMaximizedWindow === 'app',
     onClose: () => closeWindow('app'),
     onWindowPointerDown: () => focusWindow('app'),
     onHeaderPointerDown: (event) => startWindowDrag('app', event),


### PR DESCRIPTION
## 対応 issue
Closes #6

## 前提
- この PR は #7 の上に積んだ stacked PR です。
- base は `codex/issue-5-close-window` です。
- #7 が main に入った後、base を main に変更する想定です。

## 変更内容
- モバイル時専用の最大化状態を `useDesktopWindows` に追加
- モバイル幅では緑ボタンで対象ウィンドウだけを表示し、再クリックで通常表示へ復帰
- app モードでターミナルを最大化した場合、ターミナルを全高表示できるようにモバイル側の wrapper class を切り替え

## 検証
- `npm run lint`
- `npm run build`
- `git diff --check`
- 390px 幅のブラウザで初期ターミナルの最大化/復帰を確認
- 390px 幅の app モードでターミナル最大化時に app が隠れ、復帰で再表示されることを確認
- 390px 幅の app モードで app 最大化時にターミナルが隠れ、`restore window` になることを確認
- コンソールエラーなし