### PR TITLE
fix: モバイル用サイドパネル導線の追加

### DIFF
--- a/src/components/app-window/AppWindow.jsx
+++ b/src/components/app-window/AppWindow.jsx
@@ -16,6 +16,7 @@ export function AppWindow({ threadType, selectedWork, threadState, shellProps = 
   const [containerWidth, setContainerWidth] = useState(0);
   const [draggingDivider, setDraggingDivider] = useState(null);
   const [isDesktop, setIsDesktop] = useState(() => window.innerWidth >= 1024);
+  const [mobilePanel, setMobilePanel] = useState(null);
   const [columnWidths, setColumnWidths] = useState(() => {
     try {
       const savedWidths = JSON.parse(window.localStorage.getItem('portfolio-column-widths') ?? 'null');
@@ -50,6 +51,12 @@ export function AppWindow({ threadType, selectedWork, threadState, shellProps = 
     }
     setColumnWidths((currentWidths) => clampColumnWidths(currentWidths, containerWidth));
   }, [containerWidth, isDesktop]);
+
+  useEffect(() => {
+    if (isDesktop) {
+      setMobilePanel(null);
+    }
+  }, [isDesktop]);
 
   useEffect(() => {
     window.localStorage.setItem('portfolio-column-widths', JSON.stringify(columnWidths));
@@ -87,6 +94,7 @@ export function AppWindow({ threadType, selectedWork, threadState, shellProps = 
 
   useEffect(() => {
     window.scrollTo(0, 0);
+    setMobilePanel(null);
     if (centerScrollRef.current) {
       centerScrollRef.current.scrollTop = 0;
     }
@@ -120,7 +128,13 @@ export function AppWindow({ threadType, selectedWork, threadState, shellProps = 
             onToggleMaximize={onToggleMaximize}
             isMaximized={isMaximized}
           />
-          <TopBar title={threadState.title} addedCount={addedCount} onHeaderPointerDown={onHeaderPointerDown} />
+          <TopBar
+            title={threadState.title}
+            addedCount={addedCount}
+            onHeaderPointerDown={onHeaderPointerDown}
+            onOpenLeftPanel={() => setMobilePanel('left')}
+            onOpenRightPanel={() => setMobilePanel('right')}
+          />
           <CenterColumn
             threadType={threadType}
             selectedWork={selectedWork}
@@ -129,6 +143,41 @@ export function AppWindow({ threadType, selectedWork, threadState, shellProps = 
           />
           <RightColumn diffEntries={threadState.diffEntries} scrollRef={rightScrollRef} />
         </div>
+
+        {mobilePanel ? (
+          <button
+            type="button"
+            aria-label="パネルを閉じる"
+            className="absolute inset-0 z-40 bg-black/55 lg:hidden"
+            onClick={() => setMobilePanel(null)}
+          />
+        ) : null}
+
+        {mobilePanel === 'left' ? (
+          <div
+            className="absolute inset-y-0 left-0 z-50 w-[min(320px,calc(100%-48px))] bg-[#141415] lg:hidden"
+            onClick={(event) => {
+              if (event.target.closest('a')) {
+                setMobilePanel(null);
+              }
+            }}
+          >
+            <LeftSidebar
+              activeThreadType={threadType}
+              selectedWorkId={selectedWork?.id ?? null}
+              onClose={onClose}
+              onToggleMaximize={onToggleMaximize}
+              isMaximized={isMaximized}
+              variant="drawer"
+            />
+          </div>
+        ) : null}
+
+        {mobilePanel === 'right' ? (
+          <div className="absolute inset-y-0 right-0 z-50 w-[min(360px,calc(100%-48px))] bg-[#121212] lg:hidden">
+            <RightColumn diffEntries={threadState.diffEntries} variant="drawer" />
+          </div>
+        ) : null}
 
         {isDesktop && containerWidth > 0 ? (
           <>

--- a/src/components/app-window/LeftSidebar.jsx
+++ b/src/components/app-window/LeftSidebar.jsx
@@ -20,6 +20,7 @@ export function LeftSidebar({
   onClose,
   onToggleMaximize,
   isMaximized = false,
+  variant = 'desktop',
 }) {
   const [openGroups, setOpenGroups] = useState(() => ({
     top: true,
@@ -43,7 +44,13 @@ export function LeftSidebar({
   }
 
   return (
-    <aside className="relative order-4 flex min-h-0 flex-col overflow-hidden bg-[#141415] lg:order-none lg:col-start-1 lg:row-[1/3] lg:border-r lg:border-white/[0.05]">
+    <aside
+      className={`relative min-h-0 flex-col overflow-hidden bg-[#141415] ${
+        variant === 'drawer'
+          ? 'flex h-full w-full border-r border-white/[0.08]'
+          : 'hidden lg:order-none lg:col-start-1 lg:row-[1/3] lg:flex lg:border-r lg:border-white/[0.05]'
+      }`}
+    >
       <div
         onPointerDown={onHeaderPointerDown}
         className={`px-3.5 py-3 ${

--- a/src/components/app-window/RightColumn.jsx
+++ b/src/components/app-window/RightColumn.jsx
@@ -4,11 +4,15 @@ import { AddOnlyImageDiff } from './AddOnlyImageDiff';
 import { AddOnlyTextDiff } from './AddOnlyTextDiff';
 import { DiffHeader } from './DiffHeader';
 
-export function RightColumn({ diffEntries, scrollRef }) {
+export function RightColumn({ diffEntries, scrollRef, variant = 'desktop' }) {
   const totalAddedLines = getAddedLineCount(diffEntries);
 
   return (
-    <aside className="order-3 flex min-h-0 flex-col overflow-hidden bg-[#121212] lg:order-none lg:col-start-3 lg:row-start-2">
+    <aside
+      className={`min-h-0 flex-col overflow-hidden bg-[#121212] ${
+        variant === 'drawer' ? 'flex h-full w-full border-l border-white/[0.08]' : 'hidden lg:order-none lg:col-start-3 lg:row-start-2 lg:flex'
+      }`}
+    >
       <div className="flex h-10 items-center justify-between px-3">
         <div className="flex items-center gap-1.5 text-white/80">
           <ChevronRight className="h-3.5 w-3.5 text-white/38" />

--- a/src/components/app-window/TopBar.jsx
+++ b/src/components/app-window/TopBar.jsx
@@ -1,34 +1,58 @@
-import { CheckCheck, ChevronDown, GitCommitHorizontal, MoreHorizontal, Play } from 'lucide-react';
+import { CheckCheck, ChevronDown, GitCommitHorizontal, Menu, MoreHorizontal, Play } from 'lucide-react';
 
-export function TopBar({ title, addedCount, onHeaderPointerDown }) {
+export function TopBar({ title, addedCount, onHeaderPointerDown, onOpenLeftPanel, onOpenRightPanel }) {
   return (
     <header
       onPointerDown={onHeaderPointerDown}
-      className={`order-1 flex h-10 items-center justify-between border-b border-white/[0.05] bg-[#181818] px-4 lg:order-none lg:col-[2/4] lg:row-start-1 ${
+      className={`order-1 flex h-10 items-center justify-between border-b border-white/[0.05] bg-[#181818] px-2 lg:order-none lg:col-[2/4] lg:row-start-1 lg:px-4 ${
         onHeaderPointerDown ? 'cursor-grab active:cursor-grabbing' : ''
       }`}
     >
       <div className="flex min-w-0 items-center gap-2 text-[12.5px] text-white/84">
+        <button
+          type="button"
+          aria-label="左パネルを開く"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenLeftPanel?.();
+          }}
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-white/[0.06] text-white/58 hover:bg-white/[0.05] hover:text-white/84 lg:hidden"
+        >
+          <Menu className="h-4 w-4" />
+        </button>
         <span className="truncate font-medium">{title}</span>
         <MoreHorizontal className="h-3.5 w-3.5 shrink-0 text-white/34" />
       </div>
 
       <div className="flex items-center gap-1.5 text-white/46">
-        <button type="button" className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-white/[0.05] hover:bg-white/[0.05]">
+        <button type="button" className="hidden h-7 w-7 items-center justify-center rounded-md border border-white/[0.05] hover:bg-white/[0.05] sm:inline-flex">
           <Play className="h-3.5 w-3.5" />
         </button>
-        <button type="button" className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-white/[0.05] hover:bg-white/[0.05]">
+        <button type="button" className="hidden h-7 w-7 items-center justify-center rounded-md border border-white/[0.05] hover:bg-white/[0.05] sm:inline-flex">
           <CheckCheck className="h-3.5 w-3.5" />
         </button>
         <button
           type="button"
-          className="ml-1 flex items-center gap-1.5 rounded-md border border-white/[0.05] bg-white/[0.04] px-2.5 py-1 text-[11.5px] text-white/76 hover:bg-white/[0.06]"
+          className="ml-1 hidden items-center gap-1.5 rounded-md border border-white/[0.05] bg-white/[0.04] px-2.5 py-1 text-[11.5px] text-white/76 hover:bg-white/[0.06] sm:flex"
         >
           <GitCommitHorizontal className="h-3.5 w-3.5 text-white/44" />
           <span>Commit</span>
           <ChevronDown className="h-3 w-3 text-white/34" />
         </button>
-        <span className="ml-2 font-mono text-[11.5px] text-[#3fb950]">+{addedCount}</span>
+        <span className="ml-1 font-mono text-[11.5px] text-[#3fb950] lg:ml-2">+{addedCount}</span>
+        <button
+          type="button"
+          aria-label="右パネルを開く"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenRightPanel?.();
+          }}
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-white/[0.06] text-white/58 hover:bg-white/[0.05] hover:text-white/84 lg:hidden"
+        >
+          <Menu className="h-4 w-4" />
+        </button>
       </div>
     </header>
   );


### PR DESCRIPTION
## 対応課題
Closes #2

## 前提
- このプルリクエストは #8 の上に積んだ構成です。
- 基底は `codex/issue-6-mobile-green-button` です。
- #7 と #8 が main に入った後、基底を main に変更する想定です。

## 変更内容
- モバイル時に左右サイドパネルを通常の縦積み表示から外すよう変更
- 上部バー左側に左パネルを開くボタン、右側に右パネルを開くボタンを追加
- 左パネルはスレッド一覧、右パネルは差分一覧として必要時だけ描画
- 背景クリック用の閉じるボタンを追加
- デスクトップ幅では従来の3カラム表示を維持

## 検証
- `npm run lint`
- `npm run build`
- `git diff --check`
- 390px幅のapp表示で通常時に左右パネル内容が縦積み表示されないことを確認
- 390px幅で左パネルボタンからスレッド一覧が開くことを確認
- 390px幅で右パネルボタンから差分一覧が開くことを確認
- 閉じる操作で本文表示へ戻ることを確認
- 1440px幅で従来の左右パネルと中央列が同時表示されることを確認
- コンソールエラーなし