### PR TITLE
fix: モバイルapp画面の前面表示

### DIFF
--- a/src/components/workspace/WorkspaceScreen.jsx
+++ b/src/components/workspace/WorkspaceScreen.jsx
@@ -54,7 +54,7 @@ export function WorkspaceScreen({
         </div>
 
         <div className="desktop-window-reveal relative flex-1 overflow-hidden px-3 pt-3 sm:px-5 sm:pt-5 lg:p-0">
-          <div className="flex h-full flex-col gap-4 lg:hidden">
+          <div className="relative flex h-full min-h-0 flex-col gap-4 overflow-hidden lg:hidden">
             {displayMode === 'cli' ? (
               visibleWindows.terminal ? (
                 <div className="min-h-0 flex-1">
@@ -74,7 +74,7 @@ export function WorkspaceScreen({
             ) : (
               <>
                 {visibleWindows.terminal ? (
-                  <div className={terminalShellProps.isMaximized ? 'min-h-0 flex-1' : 'shrink-0'}>
+                  <div className={`relative z-10 ${terminalShellProps.isMaximized ? 'min-h-0 flex-1' : 'shrink-0'}`}>
                     <LauncherTerminalWindow
                       threadType={effectiveThreadType}
                       selectedWork={selectedWork}
@@ -90,7 +90,7 @@ export function WorkspaceScreen({
                 ) : null}
 
                 {visibleWindows.app ? (
-                  <div className="min-h-0 flex-1">
+                  <div className="absolute inset-0 z-20 min-h-0">
                     <AppWindow
                       threadType={effectiveThreadType}
                       selectedWork={selectedWork}


### PR DESCRIPTION
## 対応課題
Closes #3

## 前提
- このプルリクエストは #9 の上に積んだ構成です。
- 基底は `codex/issue-2-mobile-side-drawers` です。
- #7、#8、#9 が main に入った後、基底を main に変更する想定です。

## 変更内容
- モバイル app 表示のラッパーを相対配置に変更
- ターミナル風 UI を背面側 `z-10` に配置
- app UI を同じモバイル領域内の絶対配置 `z-20` にして、ターミナル風 UI の前面に重ねて表示

## 検証
- `npm run lint`
- `npm run build`
- `git diff --check`
- 390px幅の app 表示で、app UI がターミナル風 UI と同じ上端に重なって前面表示されることを DOM 矩形と `elementFromPoint` で確認
- app UI の `z-index:20`、ターミナル風 UI の `z-index:10` を確認
- コンソールエラーなし