### PR TITLE
fix: モバイルapp画面のスクロール改善

### DIFF
--- a/src/components/app-window/AppWindow.jsx
+++ b/src/components/app-window/AppWindow.jsx
@@ -117,7 +117,7 @@ export function AppWindow({ threadType, selectedWork, threadState, shellProps = 
     >
       <div ref={containerRef} className="relative h-full min-h-0 flex-1 overflow-hidden bg-[#111112]">
         <div
-          className="grid h-full w-full grid-cols-1 auto-rows-max lg:grid-cols-[268px_minmax(0,1fr)_864px] lg:grid-rows-[40px_minmax(0,1fr)]"
+          className="grid h-full min-h-0 w-full grid-cols-1 grid-rows-[40px_minmax(0,1fr)] lg:grid-cols-[268px_minmax(0,1fr)_864px] lg:grid-rows-[40px_minmax(0,1fr)]"
           style={gridStyle}
         >
           <LeftSidebar

--- a/src/components/app-window/CenterColumn.jsx
+++ b/src/components/app-window/CenterColumn.jsx
@@ -9,7 +9,7 @@ export function CenterColumn({ threadType, selectedWork, threadState, scrollRef 
   const isWorkDetail = Boolean(selectedWork);
 
   return (
-    <section className="order-2 flex min-h-0 flex-col overflow-hidden bg-[#111112] lg:order-none lg:col-start-2 lg:row-start-2 lg:border-r lg:border-white/[0.05]">
+    <section className="order-2 row-start-2 flex min-h-0 flex-col overflow-hidden bg-[#111112] lg:order-none lg:col-start-2 lg:row-start-2 lg:border-r lg:border-white/[0.05]">
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-5 pb-10 pt-9 lg:px-10 custom-scrollbar">
         <div className="mx-auto max-w-[820px]">
           <div className="ml-auto flex max-w-[560px] flex-col items-end">


### PR DESCRIPTION
## 対象
- #4

## 変更内容
- モバイルの app UI グリッドをヘッダー 40px と残り領域の 2 行構成に変更しました。
- 中央カラムをモバイルでも 2 行目に固定し、本文のスクロール領域へ実高さが渡るようにしました。

## 原因
- モバイル時の grid が自動行高になっており、中央カラム内の `overflow-y-auto` が使用可能な高さを正しく受け取れず、長い作品詳細で下部が見切れる状態でした。

## 検証
- `npm run lint`
- `npm run build`
- `git diff --check`
- Chrome DevTools で 390x844 のモバイル viewport を設定し、作品詳細ページ `/work/gemini-summer-boredom-collection` の中央カラムが `clientHeight 554 / scrollHeight 1123` となり、`scrollTop` が 0 から 320 に変化することを確認しました。
- Console の error/warn がないことを確認しました。