### PR TITLE
fix: ローディング表示の横幅基準化

### DIFF
--- a/src/components/onload/OnloadAnimation.jsx
+++ b/src/components/onload/OnloadAnimation.jsx
@@ -65,7 +65,7 @@ export function OnloadAnimation({ onComplete }) {
         backgroundColor={PAGE_BACKGROUND_COLOR}
         className="block h-full w-full"
         dotLottieRefCallback={handleDotLottieRef}
-        layout={{ fit: 'cover', align: [0.5, 0.5] }}
+        layout={{ fit: 'fit-width', align: [0.5, 0.5] }}
         loop={false}
         src="/onload.lottie"
         style={{ display: 'block', height: '100%', width: '100%' }}


### PR DESCRIPTION
## 対象
- Closes #1

## 変更内容
- onload 時の Lottie 表示を `cover` から `fit-width` に変更しました。
- 1920x1080 の横長アニメーションを画面の横解像度基準で描画するようにしました。

## 原因
- これまでの `cover` は縦長 viewport で高さ基準の拡大になり、横方向が大きく切れる挙動でした。

## 影響範囲
- `OnloadAnimation` の表示倍率のみです。
- アニメーション完了処理、背景化処理、UI 表示開始処理は変更していません。

## 検証
- `git diff --check`
- `npm run lint`
- `npm run build`
- Chrome DevTools で 390x844 のモバイル viewport を設定し、Lottie レイヤーが 390x844 で表示され、Vite 変換後ソースに `layout: { fit: "fit-width" }` が反映されていることを確認しました。
- `/onload.lottie` の読み込み成功、Console の error/warn なしを確認しました。